### PR TITLE
Investigate run cycle png usage issues

### DIFF
--- a/run_cycle_animation_issues.md
+++ b/run_cycle_animation_issues.md
@@ -1,0 +1,210 @@
+# Run Cycle Animation Issues Analysis
+
+## Overview
+The game is not properly using the run cycle PNG files for character animations due to several critical issues in the animation loading and rendering system. This document provides a comprehensive analysis of all identified problems.
+
+## Critical Issues Identified
+
+### 1. **Filename Path Errors**
+
+#### Run Cycle Issue:
+- **Location**: Line 102 in `sketch.js`
+- **Current Code**: `'Animation/Run Cycle/ Full sprint pose, right leg extended back, left arm pumping.png'`
+- **Problem**: Extra space before filename
+- **Actual File**: `Animation/Run Cycle/Full sprint pose, right leg extended back, left arm pumping.png`
+- **Impact**: First frame of run cycle fails to load completely
+
+#### Walk Cycle Issues (Also Affecting Animation System):
+- **Line 91**: `'Animation/Walk Cycle/ Right foot plants, body upright, hair bounces up 1 pixel.png'` (Extra space)
+- **Line 94**: `'Animation/Walk Cycle/Left foot forward, right arm forw.png'` (Truncated - missing "ard")
+
+### 2. **File Loading Verification Problems**
+
+#### Missing Error Handling:
+- The game loads animation frames but doesn't verify successful loading before starting
+- Failed frames remain `undefined` in the `animationFrames` object
+- No fallback or retry mechanism for failed loads
+
+#### Inconsistent Frame Availability:
+- **Walk Cycle**: Only 6 out of 8 frames load successfully
+- **Run Cycle**: Only 5 out of 6 frames load successfully (first frame fails)
+- **Result**: Broken animation sequences with missing frames
+
+### 3. **Animation System Logic Issues**
+
+#### Frame Indexing Problem:
+```javascript
+// In updateAnimation() function (line 1450)
+if (player.currentFrame >= animDef.frames || player.currentFrame >= currentAnim.length) {
+    player.currentFrame = 0;
+}
+```
+- When frames fail to load, `currentAnim.length` is less than `animDef.frames`
+- This causes animation to reset prematurely
+- Run cycle expects 6 frames but only has 5 available
+
+#### State Transition Logic:
+```javascript
+// In updatePlayer() function (line 687)
+if (abs(player.vx) > 3.5) {  // Running at higher speeds
+    player.state = 'run';
+} else if (abs(player.vx) > 0.5) {  // Walking at lower speeds
+    player.state = 'walk';
+}
+```
+- Logic correctly identifies when player should be running
+- But run animation fails due to missing first frame
+
+### 4. **Rendering Fallback Issues**
+
+#### Fallback Rendering Activation:
+```javascript
+// In drawPlayer() function (line 1074)
+if (currentFrame && currentFrame.width > 0) {
+    // Render PNG frame
+    image(currentFrame, 0, 0, player.width, player.height);
+} else {
+    // Fallback: Draw simple rectangular character
+    fill(255);
+    rect(0, 0, player.width * 0.8, player.height * 0.9, 5);
+}
+```
+- When run cycle frame fails to load, game shows rectangular character
+- This masks the animation failure from being obvious
+- Players see a white rectangle instead of the character PNG
+
+### 5. **File Structure Inconsistencies**
+
+#### Directory Contents vs Code Expectations:
+**Run Cycle Directory Contains:**
+1. `Right foot ready to land, completing cycle.png`
+2. `Powerful push-off left leg, hair streaming back.png`
+3. `Left foot impacts, dust particles spawn.png`
+4. `Both feet briefly off ground, body leaning forward 15°.png`
+5. `Airborne again, arms pumping opposite.png`
+6. `Full sprint pose, right leg extended back, left arm pumping.png` (with extra space)
+
+**Code Expects (in order):**
+1. `Full sprint pose, right leg extended back, left arm pumping.png` (Frame 0)
+2. `Both feet briefly off ground, body leaning forward 15°.png` (Frame 1)
+3. `Left foot impacts, dust particles spawn.png` (Frame 2)
+4. `Powerful push-off left leg, hair streaming back.png` (Frame 3)
+5. `Airborne again, arms pumping opposite.png` (Frame 4)
+6. `Right foot ready to land, completing cycle.png` (Frame 5)
+
+### 6. **Animation Timing Issues**
+
+#### Speed Configuration:
+```javascript
+const ANIMATION_DEFS = {
+    run: { frames: 6, speed: 0.25 }
+};
+```
+- Animation speed is set to 0.25 (4 frames per second)
+- With missing frames, animation becomes jerky and inconsistent
+- Player movement appears disconnected from animation
+
+### 7. **Console Error Output**
+
+#### Expected Error Messages:
+```
+Failed to load run frame 0
+Run cycle loaded 5/6 frames
+```
+- These errors indicate the loading failures
+- Game continues to run but uses fallback rendering
+
+### 8. **Performance Impact**
+
+#### Resource Loading:
+- Failed image loads cause additional HTTP requests
+- Browser console shows 404 errors for missing files
+- Impacts game loading time and performance
+
+## Impact Assessment
+
+### Visual Impact:
+- **No Run Animation**: Character appears as white rectangle when running
+- **Broken Immersion**: Static fallback breaks game's visual consistency
+- **Player Confusion**: Unclear why character appearance changes during running
+
+### Gameplay Impact:
+- **Movement Feedback**: Players lose visual feedback for running state
+- **State Confusion**: Hard to distinguish between walk and run speeds
+- **Professional Appearance**: Game appears unfinished or broken
+
+### Technical Impact:
+- **Loading Errors**: Console filled with image loading errors
+- **Memory Usage**: Undefined frame references in animation arrays
+- **Debugging Difficulty**: Fallback rendering masks the actual problem
+
+## Recommended Solutions
+
+### 1. **Fix Filename References**
+```javascript
+// Line 102 - Remove extra space
+'Animation/Run Cycle/Full sprint pose, right leg extended back, left arm pumping.png',
+
+// Line 91 - Remove extra space
+'Animation/Walk Cycle/Right foot plants, body upright, hair bounces up 1 pixel.png',
+
+// Line 94 - Complete filename
+'Animation/Walk Cycle/Left foot forward, right arm forward.png',
+```
+
+### 2. **Add Loading Verification**
+```javascript
+// In preload() function
+function verifyAnimationLoading() {
+    let walkLoaded = animationFrames.walk.filter(f => f && f.width > 0).length;
+    let runLoaded = animationFrames.run.filter(f => f && f.width > 0).length;
+    
+    console.log(`Walk cycle: ${walkLoaded}/${ANIMATION_DEFS.walk.frames} frames loaded`);
+    console.log(`Run cycle: ${runLoaded}/${ANIMATION_DEFS.run.frames} frames loaded`);
+    
+    if (walkLoaded < ANIMATION_DEFS.walk.frames || runLoaded < ANIMATION_DEFS.run.frames) {
+        console.error("Animation loading incomplete - some frames missing");
+    }
+}
+```
+
+### 3. **Improve Error Handling**
+```javascript
+// In updateAnimation() function
+if (currentAnim && currentAnim.length > 0) {
+    // Verify current frame exists
+    if (currentAnim[player.currentFrame] && currentAnim[player.currentFrame].width > 0) {
+        player.frameTimer += animDef.speed;
+        // Continue with animation logic
+    } else {
+        // Skip to next valid frame or reset
+        player.currentFrame = (player.currentFrame + 1) % currentAnim.length;
+    }
+}
+```
+
+### 4. **Add Visual Debugging**
+```javascript
+// In drawPlayer() function
+if (!currentFrame || currentFrame.width <= 0) {
+    // Add debugging info
+    console.warn(`Missing frame for state: ${player.state}, frame: ${player.currentFrame}`);
+    
+    // Enhanced fallback with state indicator
+    fill(255, 0, 0); // Red to indicate error
+    rect(0, 0, player.width * 0.8, player.height * 0.9, 5);
+    
+    // Add text indicator
+    fill(255);
+    textAlign(CENTER);
+    text(player.state.toUpperCase(), 0, 0);
+}
+```
+
+## Conclusion
+
+The primary reason the game doesn't use the run cycle PNG files is **filename path errors** causing the first frame to fail loading. This cascades into the animation system showing a fallback rectangle instead of the character sprite. Fixing the filename references would immediately restore the run cycle animation functionality.
+
+The secondary issues (walk cycle problems, error handling, verification) compound the problem and should also be addressed for a robust animation system.
+
+**Priority Fix**: Correct the filename in line 102 of `sketch.js` to remove the extra space before "Full sprint pose...".


### PR DESCRIPTION
Add `run_cycle_animation_issues.md` to document the issues preventing the game's run cycle animation from displaying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a detailed analysis of issues affecting run cycle animations, including file naming errors, missing frames, and error handling recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->